### PR TITLE
feat: examples improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,12 @@ A Python library for interacting with the Cloud One Antimalware as a Service API
 
 
 2. There are two Python examples in the folder, one with regular file i/o and one with asynchronous file i/o
-   
-   ```
+
+   ```sh
    client_aio.py
    client.py
-   ``` 
+   ```
+
 3. Current Python examples support following command line arguments
 
    | Command Line Arguments                 | Value                    | Optional |
@@ -70,10 +71,16 @@ A Python library for interacting with the Cloud One Antimalware as a Service API
    | --api_key      | Cloud One \<API KEY\>              | No       |
    | --filename or -f |        File to be scanned            | No       |
 
-
-
-4. Run one of the examples.
+4. Run one of the example for a single file.
 
    ```sh
    python3 client.py -f FILENAME -a ADDR --api_key API_KEY
    ```
+
+   or for multiples files:
+
+   ```sh
+   python3 client_multifile.py -f FILENAME1 FILENAME2 FILENAME3... -a ADDR --api_key API_KEY
+   ```
+
+   **note**: You can add as many files as you want for the multi-file example.

--- a/examples/client_aio.py
+++ b/examples/client_aio.py
@@ -1,6 +1,7 @@
 import argparse
 import time
 import asyncio
+import json
 
 import amaas.grpc.aio
 
@@ -20,7 +21,8 @@ async def main(args):
 
     elapsed = time.perf_counter() - s
 
-    print(f"scan executed in {elapsed:0.2f} seconds.")
+    result = json.loads(result[0])
+    result['scanDuration'] = f"{elapsed:0.2f}s"
 
     await amaas.grpc.aio.quit(handle)
 
@@ -47,4 +49,4 @@ if __name__ == "__main__":
 
     result = asyncio.run(main(args))
 
-    print(result)
+    print(json.dumps(result, indent=1))

--- a/examples/client_multifile.py
+++ b/examples/client_multifile.py
@@ -8,8 +8,8 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('-f', '--filename', action='store',
-                        required=True, help='file to be scanned')
+    parser.add_argument('-f', '--filename', action='store', nargs='*',
+                        required=True, help='list of files to be scanned')
     parser.add_argument('-a', '--addr', action='store', default='127.0.0.1:50051', required=False,
                         help='gRPC server address and port (default 127.0.0.1:50051)')
     parser.add_argument('-r', '--region', action='store',
@@ -27,11 +27,14 @@ if __name__ == "__main__":
     else:
         handle = amaas.grpc.init(args.addr, args.api_key, args.tls, args.ca_cert)  
 
-    s = time.perf_counter()
-    result = amaas.grpc.scan_file(args.filename, handle)
-    elapsed = time.perf_counter() - s
-    result = json.loads(result)
-    result['scanDuration'] = f"{elapsed:0.2f}s"
-    amaas.grpc.quit(handle)
 
-    print(json.dumps(result, indent=1))
+
+    for file in args.filename:
+        s = time.perf_counter()
+        result = amaas.grpc.scan_file(file, handle)
+        elapsed = time.perf_counter() - s
+        result = json.loads(result)
+        result['scanDuration'] = f"{elapsed:0.2f}s"
+        print(json.dumps(result, indent=1))
+
+    amaas.grpc.quit(handle)

--- a/examples/client_multifile.py
+++ b/examples/client_multifile.py
@@ -29,12 +29,15 @@ if __name__ == "__main__":
 
 
 
+    total_result = []
     for file in args.filename:
         s = time.perf_counter()
         result = amaas.grpc.scan_file(file, handle)
         elapsed = time.perf_counter() - s
         result = json.loads(result)
         result['scanDuration'] = f"{elapsed:0.2f}s"
-        print(json.dumps(result, indent=1))
+        total_result.append(result)
+
+    print(json.dumps(total_result, indent=1))
 
     amaas.grpc.quit(handle)


### PR DESCRIPTION
## Describe your changes
- Move the the `scan duration` to inside of the response object
- Add identation to the response to make more readable
- Print a json object as a response for all examples instead a mix of string and json
- Add an example to scan multiples files in a single gRPC session
- Update the README accordingly