### PR TITLE
fix dependent bot permission issue

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
for the dependentbot issue
https://github.com/aws-actions/configure-aws-credentials/issues/271
based on this discuss may due to the permission not setup well